### PR TITLE
Valid calls

### DIFF
--- a/lib/quick_travel/adapter.rb
+++ b/lib/quick_travel/adapter.rb
@@ -74,7 +74,10 @@ module QuickTravel
     protected
 
     def self.check_id!(id)
-      fail ArgumentError, 'id must be an integer' unless id.is_a? Integer
+      Integer(id)
+    rescue ArgumentError, # if invalid string
+           TypeError # if nil
+      fail ArgumentError, 'id must be an integer'
     end
 
     # Find first

--- a/lib/quick_travel/adapter.rb
+++ b/lib/quick_travel/adapter.rb
@@ -31,6 +31,7 @@ module QuickTravel
     end
 
     def self.find(id, opts = {})
+      check_id!(id)
       if lookup
         all.detect { |o| o.id == id.to_i }
       else
@@ -53,6 +54,7 @@ module QuickTravel
     end
 
     def self.update(id, options = {})
+      check_id!(id)
       put_and_validate("#{api_base}/#{id}.json", options)
     end
 
@@ -70,6 +72,10 @@ module QuickTravel
     end
 
     protected
+
+    def self.check_id!(id)
+      fail ArgumentError, 'id must be an integer' unless id.is_a? Integer
+    end
 
     # Find first
     def self.generic_first(request_path, opts = {})

--- a/lib/quick_travel/booking.rb
+++ b/lib/quick_travel/booking.rb
@@ -55,7 +55,7 @@ module QuickTravel
     end
 
     def country
-      Country.find(@country_id)
+      Country.find(@country_id) if @country_id
     end
 
     def deposit_due_on

--- a/lib/quick_travel/party.rb
+++ b/lib/quick_travel/party.rb
@@ -30,7 +30,9 @@ module QuickTravel
     # @returns: Party: Valid Credentials
     #          Nil: Invalid Credentialss
     def self.login(options = { login: nil, password: nil })
-      fail 'You must specify :login and :password' unless options[:login] && options[:password]
+      unless options[:login] && options[:password]
+        fail ArgumentError, 'You must specify :login and :password'
+      end
       response = post_and_validate(LOGIN_URL, options)
       Party.new(response) unless response[:error]
     end

--- a/lib/quick_travel/product.rb
+++ b/lib/quick_travel/product.rb
@@ -28,8 +28,12 @@ module QuickTravel
     #   passenger_types: {<passenger_type_id> => <num_pax>, ...},
     #   date_range: {start_date: <date>, end_date: <date>}
     def self.find(id, params = {})
-      fail 'Product#find requires passenger_type_numbers' if params[:passenger_type_numbers].blank?
-      fail 'Product#find requires date_range' if params[:date_range].blank?
+      if params[:passenger_type_numbers].blank?
+        fail ArgumentError, 'Product#find requires passenger_type_numbers'
+      end
+      if params[:date_range].blank?
+        fail ArgumentError, 'Product#find requires date_range'
+      end
       super
     end
 

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -26,10 +26,23 @@ describe QuickTravel::Product do
         passenger_type_numbers: {'1' => 1},
         rack_price_requested: true,
         date_range: {start_date: today, end_date: today + 1}
-       )
+      )
     end
 
     expect(@product.pricing_details_for_rack_rate).to be_present
+  end
+
+  it 'should ensure id is passed in correctly before calling' do
+    expect {
+      QuickTravel::Product.find(
+        nil,
+        passenger_type_numbers: {'1' => 1},
+        date_range: {start_date: today, end_date: today + 1}
+      )
+    }.to raise_error(
+      ArgumentError,
+      'id must be an integer'
+    )
   end
 end
 

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -3,6 +3,14 @@ require 'quick_travel/product'
 
 describe QuickTravel::Product do
   let(:today) { '2016-03-01'.to_date }
+  let(:options) {
+    {
+      first_travel_date: today,
+      passenger_type_numbers: {'1' => 1},
+      rack_price_requested: true,
+      date_range: {start_date: today, end_date: today + 1}
+    }
+  }
 
   before do
     VCR.use_cassette('product_show') do
@@ -21,12 +29,7 @@ describe QuickTravel::Product do
 
   it 'should return a rack minimum price when requested due to agent being logged in' do
     VCR.use_cassette('product_show_as_agent') do
-      @product = QuickTravel::Product.find(6,
-        first_travel_date: today,
-        passenger_type_numbers: {'1' => 1},
-        rack_price_requested: true,
-        date_range: {start_date: today, end_date: today + 1}
-      )
+      @product = QuickTravel::Product.find(6, options)
     end
 
     expect(@product.pricing_details_for_rack_rate).to be_present
@@ -34,15 +37,28 @@ describe QuickTravel::Product do
 
   it 'should ensure id is passed in correctly before calling' do
     expect {
-      QuickTravel::Product.find(
-        nil,
-        passenger_type_numbers: {'1' => 1},
-        date_range: {start_date: today, end_date: today + 1}
-      )
+      QuickTravel::Product.find(nil, options)
     }.to raise_error(
       ArgumentError,
       'id must be an integer'
     )
+  end
+
+  it 'shouldnt allow other strings' do
+    expect {
+      QuickTravel::Product.find('six', options)
+    }.to raise_error(
+      ArgumentError,
+      'id must be an integer'
+    )
+  end
+
+  it 'should allow string integers' do
+    expect {
+      VCR.use_cassette('product_show_as_agent') do
+        QuickTravel::Product.find('6', options)
+      end
+    }.not_to raise_error
   end
 end
 


### PR DESCRIPTION
Live CMS's are calling QT without ID's, likely coming back with adapter exceptions.

They should never attempt to call QT if they don't have ID's so stop the error at the source.

This will require broad testing!!
