### PR TITLE
Only create objects where they are expected to exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
       gemfile: gemfiles/rails4.gemfile
     - rvm: 2.2
       gemfile: gemfiles/rails2.gemfile
+    - rvm: 2.3.0
+      gemfile: gemfiles/rails2.gemfile
 notifications:
   email:
     - support@travellink.com.au

--- a/gemfiles/rails2.gemfile
+++ b/gemfiles/rails2.gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+gemspec :path => '../'
+
+group :development, :test do
+  gem 'activesupport', '~> 2.3'
+  gem 'activerecord', '~> 2.3'
+  gem 'actionpack', '~> 2.3'
+end

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+gemspec :path => '../'
+
+group :development, :test do
+  gem 'activesupport', '~> 4.2'
+  gem 'activerecord', '~> 4.2'
+  gem 'actionpack', '~> 4.2'
+end
+

--- a/lib/quick_travel/booking.rb
+++ b/lib/quick_travel/booking.rb
@@ -236,18 +236,22 @@ module QuickTravel
     end
 
     def client_address
+      return nil unless @client_address
       @client_address_object ||= Address.new(@client_address)
     end
 
     def client_party
+      return nil unless @client_party
       @client_party_object ||= Party.new(@client_party)
     end
 
     def client_contact
+      return nil unless @client_contact
       @client_contact_object ||= Contact.new(@client_contact)
     end
 
     def client
+      return nil unless @client
       @client_object ||= Client.new(@client)
     end
 

--- a/spec/booking_spec.rb
+++ b/spec/booking_spec.rb
@@ -82,6 +82,13 @@ describe QuickTravel::Booking do
       expect(booking.documents.size).to eq 1
     end
   end
+
+  it 'should not have associated client objects' do
+    expect(booking.client).to be nil
+    expect(booking.client_party).to be nil
+    expect(booking.client_contact).to be nil
+    expect(booking.client_address).to be nil
+  end
 end
 
 describe QuickTravel::Booking do

--- a/spec/booking_spec.rb
+++ b/spec/booking_spec.rb
@@ -77,6 +77,7 @@ end
 
 describe QuickTravel::Booking do
   let(:booking) { QuickTravel::Booking.find(1) }
+
   it 'should have booking documents' do
     VCR.use_cassette('booking_with_documents') do
       expect(booking.documents.size).to eq 1
@@ -84,10 +85,26 @@ describe QuickTravel::Booking do
   end
 
   it 'should not have associated client objects' do
-    expect(booking.client).to be nil
-    expect(booking.client_party).to be nil
-    expect(booking.client_contact).to be nil
-    expect(booking.client_address).to be nil
+    VCR.use_cassette('booking_with_documents') do
+      expect(booking.client).to be nil
+      expect(booking.client_party).to be nil
+      expect(booking.client_contact).to be nil
+      expect(booking.client_address).to be nil
+    end
+  end
+
+  let(:accom_product_type_id) { 2 }
+
+  it '#include_reservation_of?' do
+    VCR.use_cassette('booking_with_documents') do
+      expect(booking.include_reservation_of?(accom_product_type_id)).to be true
+    end
+  end
+
+  it '#includes_resource_class?' do
+    VCR.use_cassette('booking_with_documents') do
+      expect(booking.includes_resource_class?('Accommodation')).to be true
+    end
   end
 end
 

--- a/spec/support/coverage_loader.rb
+++ b/spec/support/coverage_loader.rb
@@ -1,4 +1,4 @@
-MINIMUM_COVERAGE = 71
+MINIMUM_COVERAGE = 74
 
 if ENV['COVERAGE'] != 'off'
   require 'simplecov'


### PR DESCRIPTION
- Currently caller (booking-app) always has client!
  Causing the wrong code path to always be taken
