### PR TITLE
Move Product from BookingApp to client

### DIFF
--- a/lib/quick_travel.rb
+++ b/lib/quick_travel.rb
@@ -17,6 +17,7 @@ module QuickTravel
 
   require 'quick_travel/product'
   require 'quick_travel/product_configuration'
+  require 'quick_travel/basic_product'
   require 'quick_travel/search'
 
   # QuickTravel models

--- a/lib/quick_travel/basic_product.rb
+++ b/lib/quick_travel/basic_product.rb
@@ -1,0 +1,58 @@
+require 'quick_travel/adapter'
+
+module QuickTravel
+  class BasicProduct < Adapter
+    def to_route_stop
+      RouteStop.new(@to_route_stop_attributes) if @to_route_stop_attributes
+    end
+
+    def from_route_stop
+      RouteStop.new(@from_route_stop_attributes) if @from_route_stop_attributes
+    end
+
+    def from_route_stop_id
+      return nil if from_route_stop.nil?
+
+      from_route_stop.id
+    end
+
+    def to_route_stop_id
+      return nil if to_route_stop.nil?
+
+      to_route_stop.id
+    end
+
+    def normally_bookable?
+      bookable || exception_type == 'inventory'
+    end
+
+    # Product.find_generic
+    #
+    #   Required: :product_type_id, :product (with sub-key :first_travel_date)
+    #   Example:
+    #     {
+    #       product_type_id:       554881965,
+    #       resource_category_id: nil,
+    #       resource_id:           nil,
+    #       location_id:           nil,
+    #       region_id:             nil,
+    #       product:               {
+    #         first_travel_date: '14-04-2010',
+    #         passenger_types: { "1" => nil, "2" => nil, "3" => nil, "4" => nil , "5" => nil },
+    #         duration: nil,
+    #         vehicle_types: {  },
+    #         quantity: nil
+    #       }
+    #     }
+    #
+    # @return
+    #   - Array of JSON objects matching the search criteria
+    #   OR
+    #   - An error string
+    def self.find(type, search_params = {})
+      url = "/reservation_for/#{type}/find_services_for.json"
+      product_maps = post_and_validate(url, search_params)
+      product_maps.map { |product_map| BasicProduct.new(product_map) }
+    end
+  end
+end

--- a/spec/basic_product_spec.rb
+++ b/spec/basic_product_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+require 'quick_travel/basic_product'
+
+describe QuickTravel::BasicProduct do
+  let(:params) {
+    {
+      product_type_id: 1,
+      route_id: 1,
+      forward: {
+        first_travel_date: date,
+        passenger_types: { '1' => '2' } # 2 adults
+      }
+    }
+  }
+  let(:date) { '2016-03-01' }
+  subject(:products) {
+    VCR.use_cassette 'basic_product_scheduled_trips' do
+      QuickTravel::BasicProduct.find(:scheduled_trips, params)
+    end
+  }
+
+  its(:size) { should == 4 }
+
+  context 'first product' do
+    subject(:product) { products.first }
+
+    it { should be_normally_bookable }
+    its(:price) { should eq 40.to_money }
+    its(:from_route_stop) { should be nil }
+    its(:to_route_stop) { should be nil }
+  end
+
+  context 'when date has no services' do
+    subject(:unbookable_products) {
+      VCR.use_cassette 'basic_product_scheduled_trips_unbookable' do
+        QuickTravel::BasicProduct.find(:scheduled_trips, params)
+      end
+    }
+    let(:date) { '2016-03-03' }
+
+    it { should be_empty }
+  end
+
+  context 'multi sector' do
+    let(:params) {
+      {
+        product_type_id: 6,
+        route_id: 3,
+        forward: {
+          first_travel_date: date,
+          from_route_stop_id: 5,
+          to_route_stop_id: 14,
+          passenger_types: { '1' => '2' } # 2 adults
+        }
+      }
+    }
+    let(:date) { '2016-03-01' }
+    subject(:products) {
+      VCR.use_cassette 'basic_product_scheduled_trips_multi_sector' do
+        QuickTravel::BasicProduct.find(:scheduled_trips, params)
+      end
+    }
+
+    its(:size) { should == 2 }
+
+    context 'first product' do
+      subject(:product) { products.first }
+
+      it { should be_normally_bookable }
+      its(:price) { should eq 30.to_money }
+      its('from_route_stop.name') { should eq 'Adelaide Central Bus Station' }
+      its('to_route_stop.name') { should eq 'Cape Jervis Ferry Terminal' }
+      its(:from_route_stop_id) { should eq 5 }
+      its(:to_route_stop_id) { should eq 14 }
+    end
+  end
+end

--- a/spec/support/cassettes/basic_product_scheduled_trips.yml
+++ b/spec/support/cassettes/basic_product_scheduled_trips.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://test.qt.sealink.com.au:8080/reservation_for/scheduled_trips/find_services_for.json
+    body:
+      encoding: UTF-8
+      string: product_type_id=1&route_id=1&forward[first_travel_date]=2016-03-01&forward[passenger_types][1]=2&access_key=<QT_KEY>
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      P3p:
+      - CP="IDC DSP CAO COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"3614f3be3466aaf7133ac72313babb3d"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 91d524692c087648a1441c481cb68a75
+      X-Runtime:
+      - '0.248636'
+      Vary:
+      - Origin
+      Date:
+      - Thu, 28 Feb 2013 13:58:07 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.2.4/2015-12-16)
+      Content-Length:
+      - '5528'
+      Connection:
+      - Keep-Alive
+      Set-Cookie:
+      - _session_id=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTU5NWIxODhiOGRmODZjZWQ2ODVkNjdlMTYxYjZhNjgzBjsAVEkiCXVzZXIGOwBGaQY%3D--488a6a29ce9432df25900b3453a9f87ede1651f9;
+        path=/; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '[{"product_id":"1","product_id_field":"trip_id","resource_id":1,"resource_class_name_underscore":"ship","product_name_underscore":"ferry","tariff_level_id":1,"service_ids":[9],"first_travel_date":"01-03-2016","last_travel_date":"01-03-2016","time_class":"","exception_type":null,"bookable_class":"
+        bookable","bookable":true,"display_text":"","from_label":"from","reason_unbookable":null,"service_notes":null,"booking_notes":null,"adjustment_notes":null,"developer_notes":null,"inventory_type_code":"A","price_in_cents":4000,"total_price_adjustment_in_cents":0,"selection_name":"06:00am
+        - KI Ferry","input_disabled":"","input_overbook":"","formatted_price":"\u003Cspan
+        class=\"money positive\"\u003E$40.00\u003C/span\u003E","price":"$40.00","formatted_pre_adjusted_price":"\u003Cspan
+        class=\"money positive\"\u003E$40.00\u003C/span\u003E","pre_adjusted_price":"$40.00","price_breakdown":"\u003Cspan\u003E\u003Cstrong\u003EPassengers:\u003C/strong\u003E\u0026nbsp;\u003Cspan
+        class=\"money positive\"\u003E$40.00\u003C/span\u003E\u0026nbsp;\u003C/span\u003E","price_breakdown_passengers_in_cents":4000,"price_breakdown_vehicles_in_cents":0,"trip_id":1,"stop_departure_time":"2000-01-01T06:00:00Z","stop_arrival_time":"2000-01-01T06:45:00Z","from_route_stop_attributes":null,"to_route_stop_attributes":null,"departure_time":"2000-01-01T06:00:00Z","arrival_time":"2000-01-01T06:45:00Z"},{"product_id":"2","product_id_field":"trip_id","resource_id":1,"resource_class_name_underscore":"ship","product_name_underscore":"ferry","tariff_level_id":1,"service_ids":[10],"first_travel_date":"01-03-2016","last_travel_date":"01-03-2016","time_class":"","exception_type":null,"bookable_class":"
+        bookable","bookable":true,"display_text":"","from_label":"from","reason_unbookable":null,"service_notes":null,"booking_notes":null,"adjustment_notes":null,"developer_notes":null,"inventory_type_code":"A","price_in_cents":4000,"total_price_adjustment_in_cents":0,"selection_name":"09:00am
+        - KI Ferry","input_disabled":"","input_overbook":"","formatted_price":"\u003Cspan
+        class=\"money positive\"\u003E$40.00\u003C/span\u003E","price":"$40.00","formatted_pre_adjusted_price":"\u003Cspan
+        class=\"money positive\"\u003E$40.00\u003C/span\u003E","pre_adjusted_price":"$40.00","price_breakdown":"\u003Cspan\u003E\u003Cstrong\u003EPassengers:\u003C/strong\u003E\u0026nbsp;\u003Cspan
+        class=\"money positive\"\u003E$40.00\u003C/span\u003E\u0026nbsp;\u003C/span\u003E","price_breakdown_passengers_in_cents":4000,"price_breakdown_vehicles_in_cents":0,"trip_id":2,"stop_departure_time":"2000-01-01T09:00:00Z","stop_arrival_time":"2000-01-01T09:45:00Z","from_route_stop_attributes":null,"to_route_stop_attributes":null,"departure_time":"2000-01-01T09:00:00Z","arrival_time":"2000-01-01T09:45:00Z"},{"product_id":"5","product_id_field":"trip_id","resource_id":1,"resource_class_name_underscore":"ship","product_name_underscore":"ferry","tariff_level_id":1,"service_ids":[13],"first_travel_date":"01-03-2016","last_travel_date":"01-03-2016","time_class":"","exception_type":null,"bookable_class":"
+        bookable","bookable":true,"display_text":"","from_label":"from","reason_unbookable":null,"service_notes":null,"booking_notes":null,"adjustment_notes":null,"developer_notes":null,"inventory_type_code":"A","price_in_cents":4000,"total_price_adjustment_in_cents":0,"selection_name":"06:00pm
+        - KI Ferry","input_disabled":"","input_overbook":"","formatted_price":"\u003Cspan
+        class=\"money positive\"\u003E$40.00\u003C/span\u003E","price":"$40.00","formatted_pre_adjusted_price":"\u003Cspan
+        class=\"money positive\"\u003E$40.00\u003C/span\u003E","pre_adjusted_price":"$40.00","price_breakdown":"\u003Cspan\u003E\u003Cstrong\u003EPassengers:\u003C/strong\u003E\u0026nbsp;\u003Cspan
+        class=\"money positive\"\u003E$40.00\u003C/span\u003E\u0026nbsp;\u003C/span\u003E","price_breakdown_passengers_in_cents":4000,"price_breakdown_vehicles_in_cents":0,"trip_id":5,"stop_departure_time":"2000-01-01T18:00:00Z","stop_arrival_time":"2000-01-01T18:45:00Z","from_route_stop_attributes":null,"to_route_stop_attributes":null,"departure_time":"2000-01-01T18:00:00Z","arrival_time":"2000-01-01T18:45:00Z"},{"product_id":"6","product_id_field":"trip_id","resource_id":1,"resource_class_name_underscore":"ship","product_name_underscore":"ferry","tariff_level_id":1,"service_ids":[14],"first_travel_date":"01-03-2016","last_travel_date":"01-03-2016","time_class":"","exception_type":null,"bookable_class":"
+        bookable","bookable":true,"display_text":"","from_label":"from","reason_unbookable":null,"service_notes":null,"booking_notes":null,"adjustment_notes":null,"developer_notes":null,"inventory_type_code":"A","price_in_cents":4000,"total_price_adjustment_in_cents":0,"selection_name":"09:00pm
+        - KI Ferry","input_disabled":"","input_overbook":"","formatted_price":"\u003Cspan
+        class=\"money positive\"\u003E$40.00\u003C/span\u003E","price":"$40.00","formatted_pre_adjusted_price":"\u003Cspan
+        class=\"money positive\"\u003E$40.00\u003C/span\u003E","pre_adjusted_price":"$40.00","price_breakdown":"\u003Cspan\u003E\u003Cstrong\u003EPassengers:\u003C/strong\u003E\u0026nbsp;\u003Cspan
+        class=\"money positive\"\u003E$40.00\u003C/span\u003E\u0026nbsp;\u003C/span\u003E","price_breakdown_passengers_in_cents":4000,"price_breakdown_vehicles_in_cents":0,"trip_id":6,"stop_departure_time":"2000-01-01T21:00:00Z","stop_arrival_time":"2000-01-01T21:45:00Z","from_route_stop_attributes":null,"to_route_stop_attributes":null,"departure_time":"2000-01-01T21:00:00Z","arrival_time":"2000-01-01T21:45:00Z"}]'
+    http_version: 
+  recorded_at: Tue, 12 Apr 2016 06:41:39 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/basic_product_scheduled_trips_multi_sector.yml
+++ b/spec/support/cassettes/basic_product_scheduled_trips_multi_sector.yml
@@ -1,0 +1,83 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://test.qt.sealink.com.au:8080/reservation_for/scheduled_trips/find_services_for.json
+    body:
+      encoding: UTF-8
+      string: product_type_id=6&route_id=3&forward[first_travel_date]=2016-03-01&forward[from_route_stop_id]=5&forward[to_route_stop_id]=14&forward[passenger_types][1]=2&access_key=<QT_KEY>
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      P3p:
+      - CP="IDC DSP CAO COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"cd3d11993df18b66625a3215b62b1895"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b71587c0c43e33d5d56d7520b92cec6b
+      X-Runtime:
+      - '0.203403'
+      Vary:
+      - Origin
+      Date:
+      - Thu, 28 Feb 2013 13:58:07 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.2.4/2015-12-16)
+      Content-Length:
+      - '4201'
+      Connection:
+      - Keep-Alive
+      Set-Cookie:
+      - _session_id=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTcyNWE1ZmU1NWVhMGEyMDBkNmRhNGU5YTliOGI0YjExBjsAVEkiCXVzZXIGOwBGaQY%3D--6b64f5c2f1d5328ed9b3aa3a6153b965bbc329b7;
+        path=/; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '[{"product_id":"9","product_id_field":"trip_id","resource_id":2,"resource_class_name_underscore":"scheduled_trip_resource","product_name_underscore":"mainland_coach_transfers","tariff_level_id":1,"service_ids":[25,26,27],"first_travel_date":"01-03-2016","last_travel_date":"01-03-2016","time_class":"","exception_type":null,"bookable_class":"
+        bookable","bookable":true,"display_text":"Advise clients times can vary by
+        up to 10mins and to be waiting in view of coach","from_label":"from","reason_unbookable":null,"service_notes":null,"booking_notes":"Advise
+        clients times can vary by up to 10mins and to be waiting in view of coach","adjustment_notes":null,"developer_notes":null,"inventory_type_code":"A","price_in_cents":3000,"total_price_adjustment_in_cents":0,"selection_name":"06:45am
+        - Ferry ConnectionDeparting Adelaide - AM","input_disabled":"","input_overbook":"","formatted_price":"\u003Cspan
+        class=\"money positive\"\u003E$30.00\u003C/span\u003E","price":"$30.00","formatted_pre_adjusted_price":"\u003Cspan
+        class=\"money positive\"\u003E$30.00\u003C/span\u003E","pre_adjusted_price":"$30.00","price_breakdown":"\u003Cspan\u003E\u003Cstrong\u003EPassengers:\u003C/strong\u003E\u0026nbsp;\u003Cspan
+        class=\"money positive\"\u003E$30.00\u003C/span\u003E\u0026nbsp;\u003C/span\u003E","price_breakdown_passengers_in_cents":3000,"price_breakdown_vehicles_in_cents":0,"trip_id":9,"stop_departure_time":"2000-01-01T06:45:00Z","stop_arrival_time":"2000-01-01T08:30:00Z","from_route_stop_attributes":{"address":"85
+        Franklin Street, Adelaide","code":"ACBS","created_at":"2013-03-01T01:49:04+10:30","id":5,"inventory_controlled":true,"name":"Adelaide
+        Central Bus Station","position":1,"route_id":3,"stop_id":3,"updated_at":"2013-03-01T01:49:04+10:30"},"to_route_stop_attributes":{"address":"Main
+        Road, Cape Jervis","code":"CPJ","created_at":"2013-03-01T01:49:04+10:30","id":14,"inventory_controlled":true,"name":"Cape
+        Jervis Ferry Terminal","position":10,"route_id":3,"stop_id":12,"updated_at":"2013-03-01T01:49:04+10:30"},"departure_time":"2000-01-01T06:00:00Z","arrival_time":"2000-01-01T08:30:00Z"},{"product_id":"13","product_id_field":"trip_id","resource_id":2,"resource_class_name_underscore":"scheduled_trip_resource","product_name_underscore":"mainland_coach_transfers","tariff_level_id":1,"service_ids":[28,29,30],"first_travel_date":"01-03-2016","last_travel_date":"01-03-2016","time_class":"","exception_type":null,"bookable_class":"
+        bookable","bookable":true,"display_text":"Advise clients times can vary by
+        up to 10mins and to be waiting in view of coach","from_label":"from","reason_unbookable":null,"service_notes":null,"booking_notes":"Advise
+        clients times can vary by up to 10mins and to be waiting in view of coach","adjustment_notes":null,"developer_notes":null,"inventory_type_code":"A","price_in_cents":3000,"total_price_adjustment_in_cents":0,"selection_name":"03:45pm
+        - Ferry ConnectionDeparting Adelaide - PM","input_disabled":"","input_overbook":"","formatted_price":"\u003Cspan
+        class=\"money positive\"\u003E$30.00\u003C/span\u003E","price":"$30.00","formatted_pre_adjusted_price":"\u003Cspan
+        class=\"money positive\"\u003E$30.00\u003C/span\u003E","pre_adjusted_price":"$30.00","price_breakdown":"\u003Cspan\u003E\u003Cstrong\u003EPassengers:\u003C/strong\u003E\u0026nbsp;\u003Cspan
+        class=\"money positive\"\u003E$30.00\u003C/span\u003E\u0026nbsp;\u003C/span\u003E","price_breakdown_passengers_in_cents":3000,"price_breakdown_vehicles_in_cents":0,"trip_id":13,"stop_departure_time":"2000-01-01T15:45:00Z","stop_arrival_time":"2000-01-01T17:30:00Z","from_route_stop_attributes":{"address":"85
+        Franklin Street, Adelaide","code":"ACBS","created_at":"2013-03-01T01:49:04+10:30","id":5,"inventory_controlled":true,"name":"Adelaide
+        Central Bus Station","position":1,"route_id":3,"stop_id":3,"updated_at":"2013-03-01T01:49:04+10:30"},"to_route_stop_attributes":{"address":"Main
+        Road, Cape Jervis","code":"CPJ","created_at":"2013-03-01T01:49:04+10:30","id":14,"inventory_controlled":true,"name":"Cape
+        Jervis Ferry Terminal","position":10,"route_id":3,"stop_id":12,"updated_at":"2013-03-01T01:49:04+10:30"},"departure_time":"2000-01-01T15:00:00Z","arrival_time":"2000-01-01T17:30:00Z"}]'
+    http_version: 
+  recorded_at: Tue, 12 Apr 2016 06:41:39 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/cassettes/basic_product_scheduled_trips_unbookable.yml
+++ b/spec/support/cassettes/basic_product_scheduled_trips_unbookable.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://test.qt.sealink.com.au:8080/reservation_for/scheduled_trips/find_services_for.json
+    body:
+      encoding: UTF-8
+      string: product_type_id=1&route_id=1&forward[first_travel_date]=2016-03-03&forward[passenger_types][1]=2&access_key=<QT_KEY>
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      P3p:
+      - CP="IDC DSP CAO COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"d751713988987e9331980363e24189ce"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - c68d0834907d70a16dcd7b8df889ab15
+      X-Runtime:
+      - '0.067009'
+      Vary:
+      - Origin
+      Date:
+      - Thu, 28 Feb 2013 13:58:07 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.2.4/2015-12-16)
+      Content-Length:
+      - '2'
+      Connection:
+      - Keep-Alive
+      Set-Cookie:
+      - _session_id=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJWFmYWI2YzYzMmNhNDdkNzNmNzE2NGRhODQyYzYxODIxBjsAVEkiCXVzZXIGOwBGaQY%3D--aa8c65e373d1ace4e5fc10e86602b065c157896e;
+        path=/; HttpOnly
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Tue, 12 Apr 2016 06:41:39 GMT
+recorded_with: VCR 3.0.1

--- a/spec/support/coverage_loader.rb
+++ b/spec/support/coverage_loader.rb
@@ -1,4 +1,4 @@
-MINIMUM_COVERAGE = 75.3
+MINIMUM_COVERAGE = 75.8
 
 if ENV['COVERAGE'] != 'off'
   require 'simplecov'


### PR DESCRIPTION
- Rename to BasicProduct to avoid conflict with product class

Bootstrap database updated in https://bitbucket.org/team-sealink/quicktravel_test/pull-requests/16/qt_client_trip_bootstrap/diff

Once this is merged and released I can PR https://bitbucket.org/team-sealink/booking-app/pull-requests/new?source=fix_booking_products&t=1
