### PR TITLE
[TT-807] add filter for empty array params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## [2.3.1]
+### Fixed
+- Omits empty array parameters
+
 ## [2.3.0]
 ### Changed
 - Change cache expiries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [2.3.0]
 ### Changed
- - Change cache expiries
+- Change cache expiries
 - Adds support for passing dates to Resource#all_with_price
 
 ### Fixed
@@ -14,21 +14,21 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [2.2.2]
 ### Changed
- - Deprecates Booking#calculate_price_quote
- - Fix when money is nil from QT
+- Deprecates Booking#calculate_price_quote
+- Fix when money is nil from QT
 
 ## [2.2.1] - 2016-04-18
 ### Fixed
- - Adds missing require for PriceQuote adapter
+- Adds missing require for PriceQuote adapter
 
 ## [2.2.0] - 2016-04-18
 ### Added
- - PriceQuote adapter
+- PriceQuote adapter
 
 ## [2.1.0] - 2016-04-13
 ### Added
- - Resource categories
- - Products
+- Resource categories
+- Products
 
 ## [2.0.0] - 2016-04-08
 ### Added

--- a/lib/quick_travel/adapter.rb
+++ b/lib/quick_travel/adapter.rb
@@ -316,7 +316,7 @@ module QuickTravel
       parsed_response.is_a?(Hash) && parsed_response.key?('error')
     end
 
-    # HTTParty v0.14.0 addressed introduced this change:
+    # HTTParty v0.14.0 introduced this change:
     #
     #   * [allow empty array to be used as param](https://github.com/jnunemaker/httparty/pull/477)
     #

--- a/lib/quick_travel/adapter.rb
+++ b/lib/quick_travel/adapter.rb
@@ -316,6 +316,16 @@ module QuickTravel
       parsed_response.is_a?(Hash) && parsed_response.key?('error')
     end
 
+    # HTTParty v0.14.0 addressed introduced this change:
+    #
+    #   * [allow empty array to be used as param](https://github.com/jnunemaker/httparty/pull/477)
+    #
+    # Unfortunately, when submitting an empty array as a parameter,
+    # Rack interprets it as an array containing an empty string:
+    #
+    #   Rack::Utils.parse_nested_query('array[]=') #=> {"array"=>[""]}
+    #
+    # The workaround is to avoid sending empty arrays to Rack based web applications
     class FilterQuery
       def initialize(query)
         @query = query

--- a/lib/quick_travel/adapter.rb
+++ b/lib/quick_travel/adapter.rb
@@ -3,6 +3,8 @@ require 'pp'
 require 'json'
 require 'active_support/core_ext'
 require 'money'
+require 'facets/hash/recurse'
+require 'facets/hash/delete_values'
 
 require 'quick_travel/config'
 require 'quick_travel/adapter_error'
@@ -247,7 +249,7 @@ module QuickTravel
       return_response_object = http_params.delete(:return_response_object)
 
       # Set default token
-      http_params[:query] ||= query
+      http_params[:query]   ||= FilterQuery.new(query).call
       http_params[:headers] ||= {}
       http_params[:headers]['Content-length'] = '0' if http_params[:body].blank?
       expect = http_params.delete(:expect)
@@ -312,6 +314,26 @@ module QuickTravel
     def self.response_contains_error?(response)
       parsed_response = response.parsed_response
       parsed_response.is_a?(Hash) && parsed_response.key?('error')
+    end
+
+    class FilterQuery
+      def initialize(query)
+        @query = query
+      end
+
+      def call
+        return @query unless @query.is_a? Hash
+        without_empty_arrays
+      end
+
+      private
+
+      def without_empty_arrays
+        @query.recurse { |hash|
+          hash.delete_values([])
+          hash
+        }
+      end
     end
   end
 end

--- a/lib/quick_travel/version.rb
+++ b/lib/quick_travel/version.rb
@@ -1,3 +1,3 @@
 module QuickTravel
-  VERSION = '2.3.0'
+  VERSION = '2.3.1'
 end

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'quick_travel/adapter'
+
+describe QuickTravel::Adapter do
+  let(:response) { double code: 200, parsed_response: parsed_response }
+  let(:parsed_response) { { test: true } }
+
+  before do
+    allow(QuickTravel::Api).to receive(:post).and_return(response)
+  end
+
+  context 'when the query contains empty arrays' do
+    let(:url) { 'http://test.quicktravel.com.au' }
+    let(:query) {
+      {
+        test: true,
+        empty_array: [],
+        sub_hash: { id: 42, values: [] }
+      }
+    }
+
+    before do
+      QuickTravel::Adapter.post_and_validate(url, query)
+    end
+
+    let(:expected_body) {
+      {
+        test: true,
+        sub_hash: { id: 42 },
+        access_key: an_instance_of(String)
+      }
+    }
+
+    let(:expected_params) { a_hash_including body: expected_body }
+
+    specify { expect(QuickTravel::Api).to have_received(:post).with(url, expected_params) }
+  end
+end


### PR DESCRIPTION
## Why?

HTTParty v0.14.0 introduced this change:
- [allow empty array to be used as param](https://github.com/jnunemaker/httparty/pull/477)

Unfortunately, when submitting an empty array as a parameter, Rack interprets it as an array containing an empty string:

``` ruby
require 'rack'
Rack::Utils.parse_nested_query('array[]=') #=> {"array"=>[""]}
```

The workaround is to avoid sending empty arrays to Rack based web applications (such as Rails based QuickTravel) 
