### PR TITLE
Handle nil values for empty lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## [2.4.1]
+### Changed
+- Handle nil values for empty lists
+
 ## [2.4.0]
 ### Changed
 - Improve error handling when non JSON response

--- a/lib/quick_travel/adapter.rb
+++ b/lib/quick_travel/adapter.rb
@@ -52,7 +52,7 @@ module QuickTravel
           "@#{relation_name}",
           begin
             klass = QuickTravel.const_get(options[:class_name] || relation_name.to_s.singularize.classify)
-            instance_variable_get("@#{relation_name}_attributes").map { |attr|
+            Array(instance_variable_get("@#{relation_name}_attributes")).map { |attr|
               klass.new(attr)
             }
           end


### PR DESCRIPTION
# Why?

The app will crash when QuickTravel returns an empty list as null.

# Testing

1. Install the gem in a CMS.
2. Create a booking in the CMS.
3. Verify that you can pay for the booking; before this PR, the CMS would crash at the checkout page.