### PR TITLE
Stop passing last_travel_date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## [2.6.0]
+### Removed
+- Stop passing last_travel_date
+
 ## [2.5.0]
 ### Added
 - Add call to get client token

--- a/lib/quick_travel/property.rb
+++ b/lib/quick_travel/property.rb
@@ -18,8 +18,7 @@ module QuickTravel
     #   { :property_type_id=>1, :location_id=>5  , :number_of_rooms => 1 ,  :product => {:first_travel_date => "07-05-2010" , :duration => 1 } }
     def self.find!(condition = {})
       condition[:number_of_rooms] = 1 if condition[:number_of_rooms].blank? ||  condition[:number_of_rooms].to_i < 1
-      condition[:last_travel_date] = condition[:product][:last_travel_date].to_date - 1 if condition[:product].try(:fetch, :last_travel_date, nil)
-      self.find_all!('/api/properties.json', condition)
+      find_all!('/api/properties.json', condition)
     end
 
     def self.load_with_pricing(id, options)


### PR DESCRIPTION
This requires those using this client to pass the last travel date in correctly.