### PR TITLE
@booking.accommodation_reserve now expects to be passed the adjusted last_travel_date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## [2.8.0]
+### Changed
+- @booking.accommodation_reserve now expects to be passed the adjusted last_travel_date
+
 ## [2.7.0]
 ### Added
 - can_choose_stops? to check if a route has more than two stops

--- a/lib/quick_travel/booking.rb
+++ b/lib/quick_travel/booking.rb
@@ -119,9 +119,6 @@ module QuickTravel
 
       last_travel_date = Date.strptime(reservations_options[:last_travel_date], '%d/%m/%Y')
 
-      # Because QT requires last-date to be the date of use, we have to subtract one
-      last_travel_date -= 1
-
       options = { reservations: reservations_options }
       options[:reservations][:last_travel_date] = last_travel_date.strftime(QT_DATE_FORMAT)
 

--- a/lib/quick_travel/version.rb
+++ b/lib/quick_travel/version.rb
@@ -1,3 +1,3 @@
 module QuickTravel
-  VERSION = '2.7.0'
+  VERSION = '2.8.0'
 end


### PR DESCRIPTION
**Why**

When booking accomodation via EcomEngine it would book one less night than expected.

**Testing**

Update EcomEngine to latest and place a booking for accommodation. Check that the number of nights is correct.