### PR TITLE
TPAPI-30 create cancel booking method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 
+## [3.1.0]
+### Added
+- API to cancel a booking
+
 ## [3.0.0]
 ### Fixed
 - Allow zero pricing for extra pick items

--- a/lib/quick_travel.rb
+++ b/lib/quick_travel.rb
@@ -1,8 +1,6 @@
 # QuickTravel
 #
 module QuickTravel
-  VERSION = '0.0.2'
-
   require 'active_support' # for .try, etc.
 
   require 'quick_travel/cache'

--- a/lib/quick_travel/booking.rb
+++ b/lib/quick_travel/booking.rb
@@ -275,6 +275,10 @@ module QuickTravel
       put_and_validate("#{api_base}/#{@id}/activate")
     end
 
+    def cancel!
+      put_and_validate("#{api_base}/#{@id}/cancel")
+    end
+
     def subscribe_to_email_list(email = nil)
       params = email.nil? ? {} : { email: email }
       put_and_validate("#{api_base}/#{@id}/subscribe_to_email_list", params)

--- a/spec/booking_spec.rb
+++ b/spec/booking_spec.rb
@@ -122,6 +122,7 @@ end
 describe QuickTravel::Booking do
   let(:booking) { QuickTravel::Booking.find(1) }
   subject(:consumer) { booking.passengers.first }
+
   it 'should updated nested attributes' do
     updated_booking = nil
     VCR.use_cassette('booking_with_nested_attributes') do
@@ -165,5 +166,23 @@ describe QuickTravel::Booking, 'when booking accommodation' do
     expect(reservation.last_travel_date).to eq '2016-03-02'.to_date
     expect(reservation.resource.name).to eq 'Executive Room'
     expect(reservation.passenger_ids).to eq booking.passenger_ids
+  end
+end
+
+describe QuickTravel::Booking, 'when changing state' do
+  let(:booking) { QuickTravel::Booking.find(2) }
+
+  it 'should be able to activate the booking' do
+    VCR.use_cassette('booking_activate') do
+      response = booking.activate!
+      expect(response["success"]).to eq true
+    end
+  end
+
+  it 'should be able to cancel the booking' do
+    VCR.use_cassette('booking_cancel') do
+      response = booking.cancel!
+      expect(response["success"]).to eq true
+    end
   end
 end

--- a/spec/support/cassettes/booking_activate.yml
+++ b/spec/support/cassettes/booking_activate.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://test.qt.sealink.com.au:8080/api/bookings/2.json
+    body:
+      encoding: UTF-8
+      string: access_key=<QT_KEY>
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      P3p:
+      - CP="IDC DSP CAO COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"f9c3f39d2b9b1d8cf382131ae097a3ef"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 86e84036182fc30c8dc7f05092153ae8
+      X-Runtime:
+      - '0.754949'
+      Vary:
+      - Origin
+      Date:
+      - Fri, 01 Jan 2016 02:30:37 GMT
+      X-Rack-Cache:
+      - miss
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.2.5/2016-04-26)
+      Content-Length:
+      - '7627'
+      Connection:
+      - Keep-Alive
+      Set-Cookie:
+      - _session_id=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJWY4MzBlNzA4ODI0YTE5ZWM1ZjNiODdiOGEyMzRlYWQyBjsAVEkiCXVzZXIGOwBGaQY%3D--c8d6e00c01ca6a6474f4bc54de9274c1f08f1456;
+        path=/; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '{"id":2,"state":"new","reference":"222224","public_comments":null,"internal_comments":null,"customer_contact_name":null,"customer_contact_phone":null,"customer_contact_mobile":null,"customer_contact_email":null,"currency_iso_code":"AUD","country_id":14,"post_code":null,"referral_code_id":1,"external_identifier":null,"created_at":"2016-05-11T13:09:47+09:30","updated_at":"2016-07-13T12:00:24+09:30","promo_code":null,"promo_code_id":null,"insurance_offered":false,"total_adjustments_in_cents":0,"pre_adjusted_gross_in_cents":25000,"nett_in_cents":25000,"gross_in_cents":25000,"commission_in_cents":0,"balance_in_cents":25000,"paid_in_cents":0,"surcharge_in_cents":0,"deposit_in_cents":0,"web_site_name":null,"deposit_relevant":false,"deposit_due_on":{"_type":"Date","_value":"2016-09-02T00:00:00+09:30"},"balance_due_on":{"_type":"Date","_value":"2016-09-02T00:00:00+09:30"},"first_travel_date":{"_type":"Date","_value":"2016-09-02"},"last_travel_date":{"_type":"Date","_value":"2016-09-02"},"complete":true,"reason_not_complete":"","first_reason_not_complete":"","discardable_in":279420,"inactivatable_in":279370,"notices":{},"client":null,"passenger_ids":[3,4],"vehicle_ids":[],"reservation_ids":[4,5],"adjustment_ids":[],"todo_items":[],"confirmation_requests":[],"passengers_attributes":[{"id":3,"title":null,"first_name":null,"last_name":null,"passenger_type_id":1,"age":30,"gender":null,"position":1},{"id":4,"title":null,"first_name":null,"last_name":null,"passenger_type_id":1,"age":30,"gender":null,"position":2}],"vehicles_attributes":[],"reservations_attributes":[{"id":4,"booking_id":2,"description":"","comment":"","active":true,"service_ids":[58],"resource_id":12,"quantity":null,"adjustments_attributes":[],"complete":true,"reason_not_complete":"","first_reason_not_complete":"","enough_time_before_travel_to_edit":true,"product_type_id":9,"itinerary_footer":false,"fare_basis_set_id":14,"manually_priced":false,"manually_assigned_fare_basis_set":false,"has_fare_basis":true,"fare_basis_season_name":"","fare_basis_pointer_id":7,"pick_up_info":null,"drop_off_info":null,"selection_name":"Dinner
+        Cruise","product_name_underscore":"cruise","resource_class_name_underscore":"generic_resource","resource_class_name":"GenericResource","has_ticket_template":false,"first_travel_date":{"_type":"Date","_value":"2016-09-02"},"last_travel_date":{"_type":"Date","_value":"2016-09-02"},"durational":false,"duration":1,"duration_units":"Days","date_start_label":"Start
+        Date:","date_end_label":"End Date:","expires":false,"expiry":"*NA*","has_skipped_reservation_groups":false,"editable_reservation_groups":[],"tariff_level_name":"Auto
+        Priced as: Rack Rate","gross_including_packaged_item_in_cents":25000,"pre_adjusted_gross_including_packaged_item_in_cents":25000,"gross_in_cents":20000,"pre_adjusted_gross_in_cents":20000,"pre_adjusted_commission_in_cents":0,"cost_in_cents":6000,"sub_items_gross_in_cents":5000,"rules":[],"package":false,"sub_reservation_depth":0,"sub_reservations_attributes":[{"id":5,"booking_id":2,"description":"","comment":null,"active":true,"service_ids":[62],"resource_id":13,"quantity":null,"adjustments_attributes":[],"complete":true,"reason_not_complete":"","first_reason_not_complete":"","enough_time_before_travel_to_edit":true,"product_type_id":9,"itinerary_footer":false,"fare_basis_set_id":16,"manually_priced":false,"manually_assigned_fare_basis_set":false,"has_fare_basis":true,"fare_basis_season_name":"","fare_basis_pointer_id":8,"pick_up_info":null,"drop_off_info":null,"selection_name":"Dinner
+        Cruise Window","product_name_underscore":"cruise","resource_class_name_underscore":"generic_resource","resource_class_name":"GenericResource","has_ticket_template":false,"first_travel_date":{"_type":"Date","_value":"2016-09-02"},"last_travel_date":{"_type":"Date","_value":"2016-09-02"},"durational":false,"duration":1,"duration_units":"Days","date_start_label":"Start
+        Date:","date_end_label":"End Date:","expires":false,"expiry":"*NA*","has_skipped_reservation_groups":false,"editable_reservation_groups":[],"tariff_level_name":"Auto
+        Priced as: Rack Rate","gross_including_packaged_item_in_cents":5000,"pre_adjusted_gross_including_packaged_item_in_cents":5000,"gross_in_cents":5000,"pre_adjusted_gross_in_cents":5000,"pre_adjusted_commission_in_cents":0,"cost_in_cents":0,"rules":[],"package":false,"sub_reservation_depth":1,"extra_pick":null,"child_resource":true,"pending_confirmation":false,"confirmation_request_fields":[],"report_reservation_changes":false,"vendor_pnr":null,"pick_up_information":null,"drop_off_information":null,"vendor_staff":null,"notes_for_vendor":null,"passenger_ids":[3,4],"passenger_splits":[{"commission_in_cents":0,"commission_percentage":"0.0","consumer_id":3,"consumer_splittable_id":5,"consumer_splittable_type":"Reservation","created_at":"2016-05-11T16:58:08+09:30","gross_in_cents":2500,"id":17,"updated_at":"2016-05-11T16:58:08+09:30"},{"commission_in_cents":0,"commission_percentage":"0.0","consumer_id":4,"consumer_splittable_id":5,"consumer_splittable_type":"Reservation","created_at":"2016-05-11T16:58:08+09:30","gross_in_cents":2500,"id":18,"updated_at":"2016-05-11T16:58:08+09:30"}],"vehicle_ids":[],"vehicle_splits":[],"consumer_grosses":{"3":2500,"4":2500}}],"extra_pick":null,"child_resource":null,"pending_confirmation":false,"confirmation_request_fields":[],"report_reservation_changes":false,"vendor_pnr":null,"pick_up_information":null,"drop_off_information":null,"vendor_staff":null,"notes_for_vendor":null,"passenger_ids":[3,4],"passenger_splits":[{"commission_in_cents":0,"commission_percentage":"0.0","consumer_id":3,"consumer_splittable_id":4,"consumer_splittable_type":"Reservation","created_at":"2016-05-11T13:10:20+09:30","gross_in_cents":10000,"id":15,"updated_at":"2016-05-11T13:10:20+09:30"},{"commission_in_cents":0,"commission_percentage":"0.0","consumer_id":4,"consumer_splittable_id":4,"consumer_splittable_type":"Reservation","created_at":"2016-05-11T13:10:20+09:30","gross_in_cents":10000,"id":16,"updated_at":"2016-05-11T13:10:20+09:30"}],"vehicle_ids":[],"vehicle_splits":[],"consumer_grosses":{"3":10000,"4":10000}}],"adjustments_attributes":[],"payments_attributes":[],"payment_types_attributes":[{"id":5,"name":"master","description":"master","transaction_fee":"0.0","active":true,"position":2,"for_frequent_traveller_redemption":false,"comment_required":false,"created_at":null,"updated_at":null,"credit_card_brand":"MasterCard","payment_method":"credit_card","gateway":"braintree","on_account":false,"ticket_holding":false,"requires_staff":false,"internal":false,"redirect":false,"background":true,"creditlink":false,"surchargeable":false},{"id":4,"name":"visa","description":"visa","transaction_fee":"0.0","active":true,"position":3,"for_frequent_traveller_redemption":false,"comment_required":false,"created_at":null,"updated_at":null,"credit_card_brand":"Visa","payment_method":"credit_card","gateway":"braintree","on_account":false,"ticket_holding":false,"requires_staff":false,"internal":false,"redirect":false,"background":true,"creditlink":false,"surchargeable":false},{"id":7,"name":"PayPal","description":"Payments
+        made via PayPal account","transaction_fee":"0.0","active":true,"position":6,"for_frequent_traveller_redemption":false,"comment_required":false,"created_at":"2013-03-01T00:00:03+10:30","updated_at":"2013-03-01T00:00:03+10:30","credit_card_brand":null,"payment_method":"paypal","gateway":"braintree","on_account":false,"ticket_holding":false,"requires_staff":false,"internal":false,"redirect":false,"background":true,"creditlink":false,"surchargeable":false}],"issued_tickets_attributes":[]}'
+    http_version: 
+  recorded_at: Tue, 20 Jun 2017 06:46:15 GMT
+- request:
+    method: put
+    uri: http://test.qt.sealink.com.au:8080/api/bookings/2/activate
+    body:
+      encoding: UTF-8
+      string: access_key=<QT_KEY>
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      P3p:
+      - CP="IDC DSP CAO COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"7363e85fe9edee6f053a4b319588c086"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - fdbb18cc915ba08eb7b99383836ddaff
+      X-Runtime:
+      - '0.412926'
+      Vary:
+      - Origin
+      Date:
+      - Fri, 01 Jan 2016 02:30:37 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.2.5/2016-04-26)
+      Content-Length:
+      - '16'
+      Connection:
+      - Keep-Alive
+      Set-Cookie:
+      - _session_id=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJWM1NjJjYTg0NGJjNTAyZGQwYjE4Mjg5N2U4YzNjNDUzBjsAVEkiCXVzZXIGOwBGaQY%3D--404ec16033facfec88e9a2ada7258dcbf1a6e41c;
+        path=/; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '{"success":true}'
+    http_version: 
+  recorded_at: Tue, 20 Jun 2017 06:46:15 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/cassettes/booking_cancel.yml
+++ b/spec/support/cassettes/booking_cancel.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://test.qt.sealink.com.au:8080/api/bookings/2.json
+    body:
+      encoding: UTF-8
+      string: access_key=<QT_KEY>
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      P3p:
+      - CP="IDC DSP CAO COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"fa1d5415892abe0aa2fdee6fb27e8bac"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - cff7d946c49579f27c1c956f1826833c
+      X-Runtime:
+      - '0.746585'
+      Vary:
+      - Origin
+      Date:
+      - Fri, 01 Jan 2016 02:30:38 GMT
+      X-Rack-Cache:
+      - miss
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.2.5/2016-04-26)
+      Content-Length:
+      - '7622'
+      Connection:
+      - Keep-Alive
+      Set-Cookie:
+      - _session_id=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTA5YmMyYzc1YTAxMDZhMWU1MjViMGI4NTY3NDcxNDJmBjsAVEkiCXVzZXIGOwBGaQY%3D--595dd5591137da8927d6a687da1b504ce6104998;
+        path=/; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '{"id":2,"state":"active","reference":"222224","public_comments":null,"internal_comments":null,"customer_contact_name":null,"customer_contact_phone":null,"customer_contact_mobile":null,"customer_contact_email":null,"currency_iso_code":"AUD","country_id":14,"post_code":null,"referral_code_id":1,"external_identifier":null,"created_at":"2016-05-11T13:09:47+09:30","updated_at":"2016-01-01T13:00:37+10:30","promo_code":null,"promo_code_id":null,"insurance_offered":false,"total_adjustments_in_cents":0,"pre_adjusted_gross_in_cents":25000,"nett_in_cents":25000,"gross_in_cents":25000,"commission_in_cents":0,"balance_in_cents":25000,"paid_in_cents":0,"surcharge_in_cents":0,"deposit_in_cents":0,"web_site_name":null,"deposit_relevant":false,"deposit_due_on":{"_type":"Date","_value":"2016-09-02T00:00:00+09:30"},"balance_due_on":{"_type":"Date","_value":"2016-09-02T00:00:00+09:30"},"first_travel_date":{"_type":"Date","_value":"2016-09-02"},"last_travel_date":{"_type":"Date","_value":"2016-09-02"},"complete":true,"reason_not_complete":"","first_reason_not_complete":"","discardable_in":60,"inactivatable_in":10,"notices":{},"client":null,"passenger_ids":[3,4],"vehicle_ids":[],"reservation_ids":[4,5],"adjustment_ids":[],"todo_items":[],"confirmation_requests":[],"passengers_attributes":[{"id":3,"title":null,"first_name":null,"last_name":null,"passenger_type_id":1,"age":30,"gender":null,"position":1},{"id":4,"title":null,"first_name":null,"last_name":null,"passenger_type_id":1,"age":30,"gender":null,"position":2}],"vehicles_attributes":[],"reservations_attributes":[{"id":4,"booking_id":2,"description":"","comment":"","active":true,"service_ids":[58],"resource_id":12,"quantity":null,"adjustments_attributes":[],"complete":true,"reason_not_complete":"","first_reason_not_complete":"","enough_time_before_travel_to_edit":true,"product_type_id":9,"itinerary_footer":false,"fare_basis_set_id":14,"manually_priced":false,"manually_assigned_fare_basis_set":false,"has_fare_basis":true,"fare_basis_season_name":"","fare_basis_pointer_id":7,"pick_up_info":null,"drop_off_info":null,"selection_name":"Dinner
+        Cruise","product_name_underscore":"cruise","resource_class_name_underscore":"generic_resource","resource_class_name":"GenericResource","has_ticket_template":false,"first_travel_date":{"_type":"Date","_value":"2016-09-02"},"last_travel_date":{"_type":"Date","_value":"2016-09-02"},"durational":false,"duration":1,"duration_units":"Days","date_start_label":"Start
+        Date:","date_end_label":"End Date:","expires":false,"expiry":"*NA*","has_skipped_reservation_groups":false,"editable_reservation_groups":[],"tariff_level_name":"Auto
+        Priced as: Rack Rate","gross_including_packaged_item_in_cents":25000,"pre_adjusted_gross_including_packaged_item_in_cents":25000,"gross_in_cents":20000,"pre_adjusted_gross_in_cents":20000,"pre_adjusted_commission_in_cents":0,"cost_in_cents":6000,"sub_items_gross_in_cents":5000,"rules":[],"package":false,"sub_reservation_depth":0,"sub_reservations_attributes":[{"id":5,"booking_id":2,"description":"","comment":null,"active":true,"service_ids":[62],"resource_id":13,"quantity":null,"adjustments_attributes":[],"complete":true,"reason_not_complete":"","first_reason_not_complete":"","enough_time_before_travel_to_edit":true,"product_type_id":9,"itinerary_footer":false,"fare_basis_set_id":16,"manually_priced":false,"manually_assigned_fare_basis_set":false,"has_fare_basis":true,"fare_basis_season_name":"","fare_basis_pointer_id":8,"pick_up_info":null,"drop_off_info":null,"selection_name":"Dinner
+        Cruise Window","product_name_underscore":"cruise","resource_class_name_underscore":"generic_resource","resource_class_name":"GenericResource","has_ticket_template":false,"first_travel_date":{"_type":"Date","_value":"2016-09-02"},"last_travel_date":{"_type":"Date","_value":"2016-09-02"},"durational":false,"duration":1,"duration_units":"Days","date_start_label":"Start
+        Date:","date_end_label":"End Date:","expires":false,"expiry":"*NA*","has_skipped_reservation_groups":false,"editable_reservation_groups":[],"tariff_level_name":"Auto
+        Priced as: Rack Rate","gross_including_packaged_item_in_cents":5000,"pre_adjusted_gross_including_packaged_item_in_cents":5000,"gross_in_cents":5000,"pre_adjusted_gross_in_cents":5000,"pre_adjusted_commission_in_cents":0,"cost_in_cents":0,"rules":[],"package":false,"sub_reservation_depth":1,"extra_pick":null,"child_resource":true,"pending_confirmation":false,"confirmation_request_fields":[],"report_reservation_changes":false,"vendor_pnr":null,"pick_up_information":null,"drop_off_information":null,"vendor_staff":null,"notes_for_vendor":null,"passenger_ids":[3,4],"passenger_splits":[{"commission_in_cents":0,"commission_percentage":"0.0","consumer_id":3,"consumer_splittable_id":5,"consumer_splittable_type":"Reservation","created_at":"2016-05-11T16:58:08+09:30","gross_in_cents":2500,"id":17,"updated_at":"2016-05-11T16:58:08+09:30"},{"commission_in_cents":0,"commission_percentage":"0.0","consumer_id":4,"consumer_splittable_id":5,"consumer_splittable_type":"Reservation","created_at":"2016-05-11T16:58:08+09:30","gross_in_cents":2500,"id":18,"updated_at":"2016-05-11T16:58:08+09:30"}],"vehicle_ids":[],"vehicle_splits":[],"consumer_grosses":{"3":2500,"4":2500}}],"extra_pick":null,"child_resource":null,"pending_confirmation":false,"confirmation_request_fields":[],"report_reservation_changes":false,"vendor_pnr":null,"pick_up_information":null,"drop_off_information":null,"vendor_staff":null,"notes_for_vendor":null,"passenger_ids":[3,4],"passenger_splits":[{"commission_in_cents":0,"commission_percentage":"0.0","consumer_id":3,"consumer_splittable_id":4,"consumer_splittable_type":"Reservation","created_at":"2016-05-11T13:10:20+09:30","gross_in_cents":10000,"id":15,"updated_at":"2016-05-11T13:10:20+09:30"},{"commission_in_cents":0,"commission_percentage":"0.0","consumer_id":4,"consumer_splittable_id":4,"consumer_splittable_type":"Reservation","created_at":"2016-05-11T13:10:20+09:30","gross_in_cents":10000,"id":16,"updated_at":"2016-05-11T13:10:20+09:30"}],"vehicle_ids":[],"vehicle_splits":[],"consumer_grosses":{"3":10000,"4":10000}}],"adjustments_attributes":[],"payments_attributes":[],"payment_types_attributes":[{"id":5,"name":"master","description":"master","transaction_fee":"0.0","active":true,"position":2,"for_frequent_traveller_redemption":false,"comment_required":false,"created_at":null,"updated_at":null,"credit_card_brand":"MasterCard","payment_method":"credit_card","gateway":"braintree","on_account":false,"ticket_holding":false,"requires_staff":false,"internal":false,"redirect":false,"background":true,"creditlink":false,"surchargeable":false},{"id":4,"name":"visa","description":"visa","transaction_fee":"0.0","active":true,"position":3,"for_frequent_traveller_redemption":false,"comment_required":false,"created_at":null,"updated_at":null,"credit_card_brand":"Visa","payment_method":"credit_card","gateway":"braintree","on_account":false,"ticket_holding":false,"requires_staff":false,"internal":false,"redirect":false,"background":true,"creditlink":false,"surchargeable":false},{"id":7,"name":"PayPal","description":"Payments
+        made via PayPal account","transaction_fee":"0.0","active":true,"position":6,"for_frequent_traveller_redemption":false,"comment_required":false,"created_at":"2013-03-01T00:00:03+10:30","updated_at":"2013-03-01T00:00:03+10:30","credit_card_brand":null,"payment_method":"paypal","gateway":"braintree","on_account":false,"ticket_holding":false,"requires_staff":false,"internal":false,"redirect":false,"background":true,"creditlink":false,"surchargeable":false}],"issued_tickets_attributes":[]}'
+    http_version: 
+  recorded_at: Tue, 20 Jun 2017 06:46:16 GMT
+- request:
+    method: put
+    uri: http://test.qt.sealink.com.au:8080/api/bookings/2/cancel
+    body:
+      encoding: UTF-8
+      string: access_key=<QT_KEY>
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      P3p:
+      - CP="IDC DSP CAO COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"7363e85fe9edee6f053a4b319588c086"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9e6570c0c769ae2ec54b467445a7aa73
+      X-Runtime:
+      - '0.832948'
+      Vary:
+      - Origin
+      Date:
+      - Fri, 01 Jan 2016 02:30:39 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.2.5/2016-04-26)
+      Content-Length:
+      - '16'
+      Connection:
+      - Keep-Alive
+      Set-Cookie:
+      - _session_id=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJWU3ODQ0MzdiMzk0YTc1ZGYwODQ5MDNjOGI3MGJhYzljBjsAVEkiCXVzZXIGOwBGaQY%3D--2380c5a5b97863f99f5cb3a66fd58943746417e2;
+        path=/; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '{"success":true}'
+    http_version: 
+  recorded_at: Tue, 20 Jun 2017 06:46:17 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
**WHY**

We need a way to be able to cancel bookings in QAPI

**TESTING**

* Create a booking in quicktravel
* `booking = QuickTravel::Booking.find(booking_id)`
* `booking.cancel!`
* Should return a 200 assuming the access key you are using matches the client that made the booking