### PR TITLE
Tpapi 38 capture quicktravel error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## [Unreleased]
+### Changed
+- Return status with QuickTravel::AdapterError
 
 ## [3.1.0]
 ### Added

--- a/lib/quick_travel/adapter_error.rb
+++ b/lib/quick_travel/adapter_error.rb
@@ -1,17 +1,20 @@
 module QuickTravel
   class AdapterError < StandardError
     attr_reader :response
+    attr_reader :status
 
     def initialize(response)
-      @response = case response
-                  when String
-                    { 'error' => response }
-                  when HTTParty::Response
-                    response.parsed_response
-                  else
-                    fail "Unexpected response type #{response.class}"\
-                         "Should be String or HTTParty::Response"
-                  end
+      case response
+        when String
+          @response = { 'error' => response }
+          @status = 422
+        when HTTParty::Response
+          @response = response.parsed_response
+          @status = response.code
+        else
+          fail "Unexpected response type #{response.class}"\
+               "Should be String or HTTParty::Response"
+      end
 
       error_message = if @response.is_a? Hash
         @response.fetch('error', "We're sorry, but something went wrong. Please call us.")

--- a/spec/booking_spec.rb
+++ b/spec/booking_spec.rb
@@ -186,3 +186,16 @@ describe QuickTravel::Booking, 'when changing state' do
     end
   end
 end
+
+describe QuickTravel::Booking, "when booking doesn't exist" do
+  let(:booking) { QuickTravel::Booking.find_by_reference('111111') }
+
+  it 'should raise an error' do
+    VCR.use_cassette('booking_non_existant') do
+      expect{ booking }.to raise_error(QuickTravel::AdapterError) { |exception|
+        expect(exception.status).to eq 404
+        expect(exception.response).to eq({'error' => "Booking not found. It may have been removed due to inactivity"})
+      }
+    end
+  end
+end

--- a/spec/support/cassettes/booking_non_existant.yml
+++ b/spec/support/cassettes/booking_non_existant.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://test.qt.sealink.com.au:8080/api/bookings/reference/111111.json
+    body:
+      encoding: UTF-8
+      string: access_key=<QT_KEY>
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 404
+      message: 'Not Found '
+    headers:
+      P3p:
+      - CP="IDC DSP CAO COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 620e301e261f4038453464856be47a9a
+      X-Runtime:
+      - '0.576024'
+      Vary:
+      - Origin
+      Date:
+      - Fri, 01 Jan 2016 02:32:07 GMT
+      X-Rack-Cache:
+      - miss
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.2.5/2016-04-26)
+      Content-Length:
+      - '73'
+      Connection:
+      - Keep-Alive
+      Set-Cookie:
+      - _session_id=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTRlNDQwYjQxYmYwODAyM2IwOTVhZWRmZmViZmM3MDFlBjsAVEkiCXVzZXIGOwBGaQY%3D--77cc7c8dff3a0d680d605543218ef1419ead29da;
+        path=/; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '{"error":"Booking not found. It may have been removed due to inactivity"}'
+    http_version: 
+  recorded_at: Tue, 04 Jul 2017 07:39:13 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/coverage_loader.rb
+++ b/spec/support/coverage_loader.rb
@@ -1,4 +1,4 @@
 require 'simplecov-rcov'
 require 'coveralls'
 require 'coverage/kit'
-Coverage::Kit.setup(minimum_coverage: 82.10)
+Coverage::Kit.setup(minimum_coverage: 82.53)


### PR DESCRIPTION
**WHY**

In order to give our third party APIs more flexibility in returning correct http status codes, we need to capture the error codes returned by quicktravel.