### PR TITLE
Reasons are now passed as an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## Unreleased
+### Added
+- Price change reasons are now passed as an array
+
 ## [3.2.0]
 ### Changed
 - Return status with QuickTravel::AdapterError

--- a/lib/quick_travel/price_changes/price_change.rb
+++ b/lib/quick_travel/price_changes/price_change.rb
@@ -2,7 +2,7 @@ module QuickTravel
   module PriceChanges
     class PriceChange
       attr_reader :target
-      attr_reader :original_price, :changed_price, :price_change, :reason
+      attr_reader :original_price, :changed_price, :price_change, :reason, :reasons
 
       delegate :positive?, :negative?, to: :price_change
 
@@ -13,6 +13,7 @@ module QuickTravel
         @changed_price  = Money.new(attrs.fetch('changed_price_in_cents'))
         @price_change   = Money.new(attrs.fetch('price_change_in_cents'))
         @reason         = attrs.fetch('reason')
+        @reasons        = attrs.fetch('reasons', [@reason])
       end
 
       def applied_on?(id, type = 'Reservation')

--- a/spec/price_changes/price_change_spec.rb
+++ b/spec/price_changes/price_change_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'quick_travel/price_changes/price_change'
+
+RSpec.describe QuickTravel::PriceChanges::PriceChange do
+  let(:attrs) { {
+		"target" => {
+			"type" => "Reservation",
+			"id" => 9915496
+		},
+		"original_price_in_cents" => 19600,
+		"changed_price_in_cents" => 18800,
+		"price_change_in_cents" => -800,
+		"reason" => "Online Discount and Special Price",
+		"reasons" => [
+			"Online Discount",
+      "Special Price"
+		],
+		"discounted_price_in_cents" => 18800,
+		"discount_in_cents" => -800,
+		"root" => {
+			"target" => {
+				"type" => "Reservation",
+				"id" => 9915496
+			},
+			"original_price_in_cents" => 19600,
+			"changed_price_in_cents" => 18800,
+			"price_change_in_cents" => -800,
+			"reason" => "Online Discount and Special Price",
+			"reasons" => [
+				"Online Discount",
+        "Special Price"
+			],
+			"discounted_price_in_cents" => 18800,
+			"discount_in_cents" => -800
+		},
+		"children" => []
+	} }
+  let(:price_change) { QuickTravel::PriceChanges::PriceChange.new(attrs) }
+
+  it 'should have the correct attributes' do
+    expect(price_change.target.type).to eq 'Reservation'
+    expect(price_change.original_price.cents).to eq 19600
+    expect(price_change.changed_price.cents).to eq 18800
+    expect(price_change.price_change.cents).to eq -800
+    expect(price_change.reason).to eq 'Online Discount and Special Price'
+    expect(price_change.reasons).to eq ['Online Discount', 'Special Price']
+  end
+end


### PR DESCRIPTION
**Why**

We need to be able to display a unique list of all adjustments applied to a booking. This falls back to the old behaviour until QT api changes are live.

**Testing**

1. Make a reservation via EcomEngine. See that there's an appropriate list of adjustments.