### PR TITLE
[TT-3278] Add full_response option to booking update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 ###
 - [TT-3147] Remove unused payment methods
+- [TT-3278] Add full_response option to booking update
 
 ## [3.4.0]
 ###

--- a/lib/quick_travel/booking.rb
+++ b/lib/quick_travel/booking.rb
@@ -59,8 +59,8 @@ module QuickTravel
     end
 
     # Update an existing booking
-    def update(options = {})
-      response = put_and_validate("#{api_base}/#{@id}.json", booking: options)
+    def update(attrs = {}, options = {})
+      response = put_and_validate("#{api_base}/#{@id}.json", options.merge(booking: attrs))
       # id is returned if other attributes change otherwise success: true
       fail AdapterError.new(response) unless response['id'] || response['success']
 


### PR DESCRIPTION
This is needed as QT now allows a full_response option to be passed.