### PR TITLE
TT-3736 reservation delete errors

### DIFF
--- a/lib/quick_travel/booking.rb
+++ b/lib/quick_travel/booking.rb
@@ -246,8 +246,8 @@ module QuickTravel
     end
 
     def clear_unfinished_reservations!
-      booking = self
-      reservations.reject(&:complete).each do |reservation|
+      booking = refresh!
+      booking.reservations.reject(&:complete).each do |reservation|
         # This will return updated booking..
         booking = delete_reservation(reservation)
       end


### PR DESCRIPTION
**WHY**
Things like [this](https://rollbar.com/SealinkTravelGroup/Ecom-Engine/items/400/?item_page=0&item_count=100&#traceback) burning through our Rollbar quota.