### PR TITLE
Add caching options to adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## Unreleased
+### Added
+- [DC-1418] Port NRMA portal availability cache back to EcomEngine
+
 ## [3.7.0]
 ### Added
 - [DC-1437] Add relationship accesssor methods

--- a/lib/quick_travel/adapter.rb
+++ b/lib/quick_travel/adapter.rb
@@ -202,7 +202,13 @@ module QuickTravel
     end
 
     def self.call_and_validate(http_method, path, query = {}, opts = {})
-      Api.call_and_validate(http_method, path, query, opts)
+      response = if opts.key? :cache
+        QuickTravel::Cache.cache(opts[:cache], opts[:cache_options]) {
+          Api.call_and_validate(http_method, path, query, opts.except(:cache, :cache_options))
+        }
+      else
+        Api.call_and_validate(http_method, path, query, opts)
+      end
     end
 
     def self.base_uri(uri = nil)

--- a/lib/quick_travel/products/base.rb
+++ b/lib/quick_travel/products/base.rb
@@ -7,13 +7,13 @@ module QuickTravel
         bookable || exception_type == 'inventory'
       end
 
-      def self.find(search_params = {})
-        find_for_type(@reservation_for_type, search_params)
+      def self.find(search_params = {}, opts = {})
+        find_for_type(@reservation_for_type, search_params, opts)
       end
 
-      def self.find_for_type(type, search_params = {})
+      def self.find_for_type(type, search_params = {}, opts = {})
         url = "/reservation_for/#{type}/find_services_for.json"
-        product_maps = post_and_validate(url, search_params)
+        product_maps = post_and_validate(url, search_params, opts)
         product_maps.map { |product_map| new(product_map) }
       end
     end


### PR DESCRIPTION
# Why
This will make it possible to add caching options to any queries talking to QT.
# Test
Pass caching options to `Adapter` class when calling API.