### PR TITLE
expose new stop long/lat information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## Unreleased
+### Changed
+
+- [DC-1767] include long/lat changes to Stop
+
 ## [3.7.0]
 ### Added
 - [DC-1437] Add relationship accesssor methods

--- a/lib/quick_travel/route_stop.rb
+++ b/lib/quick_travel/route_stop.rb
@@ -5,7 +5,14 @@ module QuickTravel
     include QuickTravel::InitFromHash
 
     def stop
-      Stop.new({ id: stop_id, name: name, code: code, address: address })
+      Stop.new({
+        id: stop_id,
+        name: name,
+        code: code,
+        address: address,
+        longitude: longitude,
+        latitude: latitude
+      })
     end
   end
 


### PR DESCRIPTION
**WHY**
This change corresponds with Work that has been done to expose Stop long/lat information in QuickTravel