### PR TITLE
Dc 2997 move qt api key to header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - [DC-1692] Fix error that can be thrown when checking if a product configuration can be priced
 
 ### Changed
+- [DC-2997] Remove API key from body, and move it to header
 - [DC-1767] include long/lat changes to Stop
 
 ## [3.7.0]

--- a/lib/quick_travel/adapter.rb
+++ b/lib/quick_travel/adapter.rb
@@ -213,6 +213,7 @@ module QuickTravel
       http_params[:query]   ||= FilterQuery.new(query).call
       http_params[:headers] ||= {}
       http_params[:headers]['Content-length'] = '0' if http_params[:body].blank?
+      http_params[:headers]['x-api-key'] = QuickTravel.config.access_key
       expect = http_params.delete(:expect)
 
       # Use :body instead of :query for put/post.
@@ -222,7 +223,6 @@ module QuickTravel
       if [:put, :post].include?(http_method.to_sym)
         http_params[:body].merge!(http_params.delete(:query))
       end
-      http_params[:body][:access_key] = QuickTravel.config.access_key
       http_params[:follow_redirects] = false
 
       begin

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -26,8 +26,7 @@ describe QuickTravel::Adapter do
     let(:expected_body) {
       {
         test: true,
-        sub_hash: { id: 42 },
-        access_key: an_instance_of(String)
+        sub_hash: { id: 42 }
       }
     }
 

--- a/spec/support/cassettes/accommodation_reserve.yml
+++ b/spec/support/cassettes/accommodation_reserve.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/reservation_for/accommodations/create_or_update.json
     body:
       encoding: UTF-8
-      string: reservations[resource_id]=6&reservations[bed_configuration_id]=1&reservations[first_travel_date]=01%2F03%2F2016&reservations[last_travel_date]=02%2F03%2F2016&booking_id=4&access_key=<QT_KEY>
+      string: reservations[resource_id]=6&reservations[bed_configuration_id]=1&reservations[first_travel_date]=01%2F03%2F2016&reservations[last_travel_date]=02%2F03%2F2016&booking_id=4
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200
@@ -59,10 +61,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/4.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200
@@ -124,10 +128,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/4.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200
@@ -189,10 +195,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/resources/6.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/basic_product_scheduled_trips.yml
+++ b/spec/support/cassettes/basic_product_scheduled_trips.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/reservation_for/scheduled_trips/find_services_for.json
     body:
       encoding: UTF-8
-      string: product_type_id=1&route_id=1&forward[first_travel_date]=2016-03-01&forward[passenger_types][1]=2&access_key=<QT_KEY>
+      string: product_type_id=1&route_id=1&forward[first_travel_date]=2016-03-01&forward[passenger_types][1]=2
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/basic_product_scheduled_trips_multi_sector.yml
+++ b/spec/support/cassettes/basic_product_scheduled_trips_multi_sector.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/reservation_for/scheduled_trips/find_services_for.json
     body:
       encoding: UTF-8
-      string: product_type_id=6&route_id=3&forward[first_travel_date]=2016-03-01&forward[from_route_stop_id]=5&forward[to_route_stop_id]=14&forward[passenger_types][1]=2&access_key=<QT_KEY>
+      string: product_type_id=6&route_id=3&forward[first_travel_date]=2016-03-01&forward[from_route_stop_id]=5&forward[to_route_stop_id]=14&forward[passenger_types][1]=2
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/basic_product_scheduled_trips_unbookable.yml
+++ b/spec/support/cassettes/basic_product_scheduled_trips_unbookable.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/reservation_for/scheduled_trips/find_services_for.json
     body:
       encoding: UTF-8
-      string: product_type_id=1&route_id=1&forward[first_travel_date]=2016-03-03&forward[passenger_types][1]=2&access_key=<QT_KEY>
+      string: product_type_id=1&route_id=1&forward[first_travel_date]=2016-03-03&forward[passenger_types][1]=2
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/booking_activate.yml
+++ b/spec/support/cassettes/booking_activate.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/2.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200
@@ -69,10 +71,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/2/activate
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/booking_cancel.yml
+++ b/spec/support/cassettes/booking_cancel.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/2.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200
@@ -69,10 +71,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/2/cancel
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/booking_create.yml
+++ b/spec/support/cassettes/booking_create.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/booking_create_accommodation.yml
+++ b/spec/support/cassettes/booking_create_accommodation.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/booking_documents.yml
+++ b/spec/support/cassettes/booking_documents.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/3/documents.json?last_group=true&regenerate=false
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/booking_non_existant.yml
+++ b/spec/support/cassettes/booking_non_existant.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/reference/111111.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 404

--- a/spec/support/cassettes/booking_price_changes.yml
+++ b/spec/support/cassettes/booking_price_changes.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/1/price_change.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/booking_show.yml
+++ b/spec/support/cassettes/booking_show.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/3.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/booking_update.yml
+++ b/spec/support/cassettes/booking_update.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/3.json
     body:
       encoding: UTF-8
-      string: booking[customer_contact_name]=John&access_key=<QT_KEY>
+      string: booking[customer_contact_name]=John
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200
@@ -63,10 +65,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/3.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/booking_with_documents.yml
+++ b/spec/support/cassettes/booking_with_documents.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/1.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200
@@ -88,10 +90,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/1/documents.json?last_group=true&regenerate=false
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/booking_with_nested_attributes.yml
+++ b/spec/support/cassettes/booking_with_nested_attributes.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/1.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200
@@ -88,10 +90,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/1/update_with_nested_attributes.json
     body:
       encoding: UTF-8
-      string: booking[customer_contact_name]=New%20Name&booking[consumers][][id]=1&booking[consumers][][title]=Mr&booking[consumers][][first_name]=New&booking[consumers][][last_name]=Name&access_key=<QT_KEY>
+      string: booking[customer_contact_name]=New%20Name&booking[consumers][][id]=1&booking[consumers][][title]=Mr&booking[consumers][][first_name]=New&booking[consumers][][last_name]=Name
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200
@@ -144,10 +148,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/1.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/booking_with_price_changes.yml
+++ b/spec/support/cassettes/booking_with_price_changes.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/reference/222223.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/checkout_client_token.yml
+++ b/spec/support/cassettes/checkout_client_token.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/checkouts/client_token.json?gateway=braintree
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/client_templates.yml
+++ b/spec/support/cassettes/client_templates.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/clients/2.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200
@@ -61,10 +63,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/clients/2/templates
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/countries.yml
+++ b/spec/support/cassettes/countries.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/countries.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/country_all.yml
+++ b/spec/support/cassettes/country_all.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/countries.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/create_reservation_fail.yml
+++ b/spec/support/cassettes/create_reservation_fail.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/reservations.json
     body:
       encoding: UTF-8
-      string: resource_id=4&first_travel_date=2099-09-10&access_key=<QT_KEY>
+      string: resource_id=4&first_travel_date=2099-09-10
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 404

--- a/spec/support/cassettes/create_reservation_with_booking.yml
+++ b/spec/support/cassettes/create_reservation_with_booking.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/reservations.json
     body:
       encoding: UTF-8
-      string: resource_id=4&first_travel_date=2016-03-01&passenger_types_numbers[1]=2&passenger_types_numbers[2]=1&access_key=<QT_KEY>
+      string: resource_id=4&first_travel_date=2016-03-01&passenger_types_numbers[1]=2&passenger_types_numbers[2]=1
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/locations.yml
+++ b/spec/support/cassettes/locations.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/locations.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/opal_modern_pay_failed_booking.yml
+++ b/spec/support/cassettes/opal_modern_pay_failed_booking.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/opal_modern_pay_failed_create.yml
+++ b/spec/support/cassettes/opal_modern_pay_failed_create.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/checkouts.json
     body:
       encoding: UTF-8
-      string: booking_id=5&payment[payment_type_id]=10&payment[amount_in_cents]=10&payment[uid]=modern-opal-failed-uid&payment[comment]=Test%20Opal%20Payment&access_key=<QT_KEY>
+      string: booking_id=5&payment[payment_type_id]=10&payment[amount_in_cents]=10&payment[uid]=modern-opal-failed-uid&payment[comment]=Test%20Opal%20Payment
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/opal_modern_pay_failed_update.yml
+++ b/spec/support/cassettes/opal_modern_pay_failed_update.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/checkouts/modern-opal-failed-uid.json
     body:
       encoding: UTF-8
-      string: gateway_response[raw_response]=%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardNumber%22%3A%203085227007682330%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardBalance%22%3A%206546%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardSequenceNumber%22%3A%2055%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CILAmount%22%3A%200%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22AuthorizedAmount%22%3A%20890%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22SalesReferenceNumber%22%3A%2053183943%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22TransactionDTM%22%3A%20%222018-01-04T09%3A00%3A43.106%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22VoidTransactionReferenceNumber%22%3A%201271099697%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardBlockState%22%3A%20false%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22AutoloadAmount%22%3A%200%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D&gateway_response[success]=false&gateway_response[meta_data][applicationInstanceId]=101166&gateway_response[meta_data][operatorId]=an_operator&access_key=<QT_KEY>
+      string: gateway_response[raw_response]=%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardNumber%22%3A%203085227007682330%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardBalance%22%3A%206546%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardSequenceNumber%22%3A%2055%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CILAmount%22%3A%200%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22AuthorizedAmount%22%3A%20890%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22SalesReferenceNumber%22%3A%2053183943%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22TransactionDTM%22%3A%20%222018-01-04T09%3A00%3A43.106%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22VoidTransactionReferenceNumber%22%3A%201271099697%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardBlockState%22%3A%20false%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22AutoloadAmount%22%3A%200%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D&gateway_response[success]=false&gateway_response[meta_data][applicationInstanceId]=101166&gateway_response[meta_data][operatorId]=an_operator
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 422

--- a/spec/support/cassettes/opal_modern_pay_successful_booking.yml
+++ b/spec/support/cassettes/opal_modern_pay_successful_booking.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/opal_modern_pay_successful_response.yml
+++ b/spec/support/cassettes/opal_modern_pay_successful_response.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/checkouts.json
     body:
       encoding: UTF-8
-      string: booking_id=6&payment[payment_type_id]=10&payment[amount_in_cents]=10&payment[uid]=modern-opal-uid&payment[comment]=Test%20Opal%20Payment&access_key=<QT_KEY>
+      string: booking_id=6&payment[payment_type_id]=10&payment[amount_in_cents]=10&payment[uid]=modern-opal-uid&payment[comment]=Test%20Opal%20Payment
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/opal_modern_pay_successful_update_response.yml
+++ b/spec/support/cassettes/opal_modern_pay_successful_update_response.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/checkouts/modern-opal-uid.json
     body:
       encoding: UTF-8
-      string: gateway_response[raw_response]=%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardNumber%22%3A%203085227007682330%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardBalance%22%3A%206546%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardSequenceNumber%22%3A%2055%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CILAmount%22%3A%200%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22AuthorizedAmount%22%3A%20890%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22SalesReferenceNumber%22%3A%2053183943%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22TransactionDTM%22%3A%20%222018-01-04T09%3A00%3A43.106%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22TransactionReferenceNumber%22%3A%201271099697%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardBlockState%22%3A%20false%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22AutoloadAmount%22%3A%200%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D&gateway_response[success]=true&gateway_response[meta_data][applicationInstanceId]=101166&gateway_response[meta_data][operatorId]=an_operator&access_key=<QT_KEY>
+      string: gateway_response[raw_response]=%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardNumber%22%3A%203085227007682330%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardBalance%22%3A%206546%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardSequenceNumber%22%3A%2055%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CILAmount%22%3A%200%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22AuthorizedAmount%22%3A%20890%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22SalesReferenceNumber%22%3A%2053183943%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22TransactionDTM%22%3A%20%222018-01-04T09%3A00%3A43.106%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22TransactionReferenceNumber%22%3A%201271099697%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22CardBlockState%22%3A%20false%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22AutoloadAmount%22%3A%200%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D&gateway_response[success]=true&gateway_response[meta_data][applicationInstanceId]=101166&gateway_response[meta_data][operatorId]=an_operator
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/opal_pay.yml
+++ b/spec/support/cassettes/opal_pay.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/checkouts.json
     body:
       encoding: UTF-8
-      string: booking_id=7&payment[gateway_response]=%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22CardNumber%22%3A%203085227007682330%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22CardBalance%22%3A%206546%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22CardSequenceNumber%22%3A%2055%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22CILAmount%22%3A%200%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22AuthorizedAmount%22%3A%20890%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22SalesReferenceNumber%22%3A%2053183943%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22TransactionDTM%22%3A%20%222018-01-04T09%3A00%3A43.106%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22TransactionReferenceNumber%22%3A%201271099697%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22CardBlockState%22%3A%20false%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22AutoloadAmount%22%3A%200%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D&payment[payment_type_id]=10&payment[amount_in_cents]=10&payment[uid]=opal-uid&payment[comment]=Test%20Opal%20Payment&payment[meta_data][applicationInstanceId]=101166&payment[meta_data][operatorId]=an_operator&access_key=<QT_KEY>
+      string: booking_id=7&payment[gateway_response]=%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22CardNumber%22%3A%203085227007682330%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22CardBalance%22%3A%206546%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22CardSequenceNumber%22%3A%2055%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22CILAmount%22%3A%200%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22AuthorizedAmount%22%3A%20890%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22SalesReferenceNumber%22%3A%2053183943%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22TransactionDTM%22%3A%20%222018-01-04T09%3A00%3A43.106%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22TransactionReferenceNumber%22%3A%201271099697%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22CardBlockState%22%3A%20false%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22AutoloadAmount%22%3A%200%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D&payment[payment_type_id]=10&payment[amount_in_cents]=10&payment[uid]=opal-uid&payment[comment]=Test%20Opal%20Payment&payment[meta_data][applicationInstanceId]=101166&payment[meta_data][operatorId]=an_operator
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/opal_pay_booking.yml
+++ b/spec/support/cassettes/opal_pay_booking.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/passenger_all.yml
+++ b/spec/support/cassettes/passenger_all.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/passenger_types.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/payment_info.yml
+++ b/spec/support/cassettes/payment_info.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/payment_types/information.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/price_quote.yml
+++ b/spec/support/cassettes/price_quote.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/price_quotes/calculate
     body:
       encoding: UTF-8
-      string: reservations[][resource_id]=7&reservations[][quantity]=2&reservations[][first_travel_date]=2016-04-15&access_key=<QT_KEY>
+      string: reservations[][resource_id]=7&reservations[][quantity]=2&reservations[][first_travel_date]=2016-04-15
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200
@@ -61,10 +63,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/price_quotes/calculate
     body:
       encoding: UTF-8
-      string: reservations[][resource_id]=7&reservations[][quantity]=3&reservations[][first_travel_date]=2016-04-15&access_key=<QT_KEY>
+      string: reservations[][resource_id]=7&reservations[][quantity]=3&reservations[][first_travel_date]=2016-04-15
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/product_date_range_bookability.yml
+++ b/spec/support/cassettes/product_date_range_bookability.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/products/date_range_bookability.json?default_pax_type_numbers%5B%5D=1&duration=7&passenger_type_numbers%5B%5D=1&passenger_type_numbers%5B%5D=2&resource_ids%5B%5D=3&resource_ids%5B%5D=4&resource_ids%5B%5D=6&travel_date=2016-03-01
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/product_show.yml
+++ b/spec/support/cassettes/product_show.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/products/6.json?date_range%5Bend_date%5D=2016-03-02&date_range%5Bstart_date%5D=2016-03-01&first_travel_date=2016-03-01&passenger_type_numbers%5B%5D=1
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/product_show_as_agent.yml
+++ b/spec/support/cassettes/product_show_as_agent.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/products/6.json?date_range%5Bend_date%5D=2016-03-02&date_range%5Bstart_date%5D=2016-03-01&first_travel_date=2016-03-01&passenger_type_numbers%5B%5D=1&rack_price_requested=true
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/product_type_all.yml
+++ b/spec/support/cassettes/product_type_all.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/product_types.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/product_type_resource_categories.yml
+++ b/spec/support/cassettes/product_type_resource_categories.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/resource_categories.json?product_type_ids%5B%5D=1
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/product_type_resource_categories_tickets.yml
+++ b/spec/support/cassettes/product_type_resource_categories_tickets.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/resource_categories.json?product_type_ids%5B%5D=5
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/product_type_routes.yml
+++ b/spec/support/cassettes/product_type_routes.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/product_types/1/routes.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/property.yml
+++ b/spec/support/cassettes/property.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/properties/1.json?product%5Bfirst_travel_date%5D=2016-01-01
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/property_types.yml
+++ b/spec/support/cassettes/property_types.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/property_types.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/region_show.yml
+++ b/spec/support/cassettes/region_show.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/regions.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/reservation_resource.yml
+++ b/spec/support/cassettes/reservation_resource.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/resources/6.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/reservation_with_extra_picks.yml
+++ b/spec/support/cassettes/reservation_with_extra_picks.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/bookings/1.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200
@@ -89,10 +91,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/resources/4.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200
@@ -149,10 +153,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/resources/3.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/resource_category_all.yml
+++ b/spec/support/cassettes/resource_category_all.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/resource_categories.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/resource_category_all_for_product_type_8.yml
+++ b/spec/support/cassettes/resource_category_all_for_product_type_8.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/resource_categories.json?product_type_ids%5B%5D=8
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/resource_fare_bases.yml
+++ b/spec/support/cassettes/resource_fare_bases.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/resources.json?parent_resource_id=6
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/resource_show.yml
+++ b/spec/support/cassettes/resource_show.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/resources/6.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/resource_with_price.yml
+++ b/spec/support/cassettes/resource_with_price.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/resources/index_with_price.json?product_type_ids=5
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/settings_basic.yml
+++ b/spec/support/cassettes/settings_basic.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/settings/basic.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/tenant_switcher.yml
+++ b/spec/support/cassettes/tenant_switcher.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: http://test.qt.sealink.com.au:8080/api/product_types.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 200
@@ -67,10 +69,12 @@ http_interactions:
     uri: http://test.qt.other.com.au:8080/api/product_types.json
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY_2>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY_2>
   response:
     status:
       code: 200

--- a/spec/support/cassettes/wrong_url.yml
+++ b/spec/support/cassettes/wrong_url.yml
@@ -5,10 +5,12 @@ http_interactions:
     uri: https://httpstat.us/418
     body:
       encoding: UTF-8
-      string: access_key=<QT_KEY>
+      string: ''
     headers:
       Content-Length:
       - '0'
+      X-API-KEY:
+      - <QT_KEY>
   response:
     status:
       code: 418


### PR DESCRIPTION
### Why
qt access key is currently being sent in body not header, it results in access key exposing in rollbar logs when error happens. Example: https://rollbar.com/sealink-travel-group/QuickTravel/items/16374/?item_page=0&item_count=100&#instances
### Test
We should not be able to see api key in Rollbar any more, and everything else should work fine.