### PR TITLE
Add API namespace to vehicle_types endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## Unreleased
+
 - [TT-7788] Add API namespace to vehicle_types endpoint
 
 ## [4.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## Unreleased
+- [TT-7788] Add API namespace to vehicle_types endpoint
+
 ## [4.0.0]
 - [TT-7385] Update Money dependency, test against Ruby 2.7 / Rails 6
 

--- a/lib/quick_travel/vehicle_type.rb
+++ b/lib/quick_travel/vehicle_type.rb
@@ -2,7 +2,7 @@ require 'quick_travel/adapter'
 
 module QuickTravel
   class VehicleType < Adapter
-    self.api_base = '/vehicle_types'
+    self.api_base = '/api/vehicle_types'
     self.lookup = true
   end
 end


### PR DESCRIPTION
**WHAT:** The API should be using the API namespace, permission issues exist for QLD when the vehicle_types are nil. The API namespace gives me an empty array, while without it I get 403.