### PR TITLE
TT-8142: Add user-agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## Unreleased
+### Changed
+- [TT-8142] Add suitable user-agent header
+
 ## [4.2.0]
 ### Changed
 - [TT-7969] Update cassettes to work with HttpParty >= 0.18.1

--- a/lib/quick_travel/adapter.rb
+++ b/lib/quick_travel/adapter.rb
@@ -214,6 +214,8 @@ module QuickTravel
       http_params[:headers] ||= {}
       http_params[:headers]['Content-length'] = '0' if http_params[:body].blank?
       http_params[:headers]['x-api-key'] = QuickTravel.config.access_key
+      http_params[:headers]['user-agent'] = 'quicktravel_client/' + QuickTravel::VERSION;
+
       expect = http_params.delete(:expect)
 
       # Use :body instead of :query for put/post.


### PR DESCRIPTION
Label requests as coming from this library and include the version, otherwise it is just 'Ruby' which is pretty unhelpful.