### PR TITLE
Fix QuickTravel::VERSION missing const error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
-## [4.3.1]
+## [4.3.1 Unreleased]
 ### Fixed
 - [TT-8471] Fix missing QuickTravel:VERSION const error
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## [4.3.1]
+### Fixed
+- [TT-8471] Fix missing QuickTravel:VERSION const error
+
 ## [4.3.0]
 ### Changed
 - [TT-8142] Add suitable user-agent header

--- a/lib/quick_travel/adapter.rb
+++ b/lib/quick_travel/adapter.rb
@@ -9,6 +9,7 @@ require 'facets/hash/delete_values'
 require 'quick_travel/config'
 require 'quick_travel/adapter_error'
 require 'quick_travel/init_from_hash'
+require 'quick_travel/version'
 
 module QuickTravel
   class Adapter


### PR DESCRIPTION
### WHY

When integrating new version into ECOM engine hit the following error:

uninitialized constant QuickTravel::VERSION
