### PR TITLE
Tt 8511 revert party api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## [Unreleased]
+### Fixed
+- [TT-8511] Revert party lookup via the API endpoint
+
 ## [4.3.1]
 ### Fixed
 - [TT-8471] Fix missing QuickTravel:VERSION const error

--- a/lib/quick_travel/party.rb
+++ b/lib/quick_travel/party.rb
@@ -12,10 +12,14 @@ module QuickTravel
       end
     end
 
-    self.api_base = '/api/parties'
+    self.api_base = '/parties'
 
     def self.find_by_login(options)
       get_and_validate('/parties/find_by_login.json', options)
+    end
+
+    def self.create(options = {})
+      post_and_validate("/api/parties.json", options)
     end
 
     # Asks QuickTravel to check the credentials

--- a/lib/quick_travel/party.rb
+++ b/lib/quick_travel/party.rb
@@ -7,9 +7,10 @@ module QuickTravel
 
     def initialize(hash = {})
       super
-      if type.blank?
-        @type = 'Person'
-      end
+      # TODO Fix the QT endpoint to actual return the type, first step
+      # is to revert it so we can fix the pacts, than we can update the
+      # expectations to include a return value
+      @type = 'Person'
     end
 
     self.api_base = '/parties'


### PR DESCRIPTION
### WHY

Turns out the front_office/parties GET and the api/parties get are vastly different. 
I have reverted the global change to api and left just the create there.
