### PR TITLE
TT-9346: Support injection of additional headers in requests to qt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## Unreleased
 
+- [TT-9346] Support injection of additional headers in requests to quicktravel
 - [TT-9331] Cache resources to reduce unnecessary API requests
 
 ## 4.4.0

--- a/lib/quick_travel/adapter.rb
+++ b/lib/quick_travel/adapter.rb
@@ -216,6 +216,7 @@ module QuickTravel
       http_params[:headers]['Content-length'] = '0' if http_params[:body].blank?
       http_params[:headers]['x-api-key'] = QuickTravel.config.access_key
       http_params[:headers]['user-agent'] = 'quicktravel_client/' + QuickTravel::VERSION;
+      http_params[:headers].merge!(extra_headers) if extra_headers
 
       expect = http_params.delete(:expect)
 
@@ -252,6 +253,10 @@ module QuickTravel
       validate!(response)
 
       response
+    end
+
+    def self.extra_headers
+      QuickTravel.config.extra_headers
     end
 
     # Do standard validations on response

--- a/lib/quick_travel/config.rb
+++ b/lib/quick_travel/config.rb
@@ -2,7 +2,7 @@ require 'quick_travel/adapter'
 
 module QuickTravel
   class Configuration
-    attr_accessor :url, :access_key, :version
+    attr_accessor :url, :access_key, :version, :extra_headers
 
     def url=(url)
       @url = url

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -83,4 +83,28 @@ describe QuickTravel::Adapter do
       specify { expect(api).to have_received(:call_and_validate).twice }
     end
   end
+
+  context 'extra headers defined' do
+    let(:url) { 'http://test.quicktravel.com.au' }
+    let(:query) { {} }
+    let(:change_config) { }
+    let(:useragent) { 'rspec' }
+
+    before do
+      change_config
+      QuickTravel::Adapter.post_and_validate(url, query)
+    end
+
+    let(:expected_params) { a_hash_including(headers: a_hash_including('user-agent' => useragent)) }
+
+    specify { expect(QuickTravel::Api).to have_received(:post).with(url, expected_params) }
+
+    context 'and the config is changed' do
+      let(:useragent) { 'newspec' }
+      let(:change_config) {
+        QuickTravel.config.extra_headers = { 'user-agent' => 'newspec' }
+      }
+      specify { expect(QuickTravel::Api).to have_received(:post).with(url, expected_params) }
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ qt_keys = ENV['QT_KEYS'].split(',')
 QuickTravel.configure do |c|
   c.url = 'http://test.qt.sealink.com.au:8080'
   c.access_key = qt_keys[0]
+  c.extra_headers = { 'user-agent' => 'rspec' }
 end
 
 require 'quick_travel/connection_error'

--- a/spec/support/coverage_loader.rb
+++ b/spec/support/coverage_loader.rb
@@ -1,4 +1,4 @@
 require 'simplecov-rcov'
 require 'coveralls'
 require 'coverage/kit'
-Coverage::Kit.setup(minimum_coverage: 83.2)
+Coverage::Kit.setup(minimum_coverage: 83.7)


### PR DESCRIPTION
Allow setting arbitrary extra headers from application side.

This permits sending additional contextual information with requests for logging.